### PR TITLE
Allow insecure http

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,5 +8,8 @@
             "type": "pear",
             "url": "http://pear.php.net"
         }
-    ]
+    ],
+    "config": {
+        "secure-http": "false"
+    }
 }


### PR DESCRIPTION
Composer for some reason tries to use http for fetching PEAR packages, which leads to an error, since `secure-http` defaults to `true`. I have tried changing the url of the pear repository to use https, but it did not help. Looking at the composer code, I concluded that disabling `secure-http` is the only feasible solution. Other solution would probably be to not use pear repository, but use a composer one. I don't feel on doing that one, so if you think it would be a better solution, feel free to close this one and do another PR. :)

This is a fix for RHBZ 1313779.
